### PR TITLE
README.md: Add ssl error fix during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ editor.
 1.  Install [coala](https://github.com/coala-analyzer/coala)
 2.  `apm install coala` or use the atom GUI
 
-    Note: If the `linter` atom package is not currently installed, it will be installed for you.
+    Note:
+     * If the `linter` atom package is not currently installed, it will be installed for you.
+     * If you are behind a firewall and seeing SSL errors when installing packages, you may find the fix at [atom manual](http://flight-manual.atom.io/getting-started/sections/installing-atom/#setting-up-a-proxy)
 
 # AUTHORS
 


### PR DESCRIPTION
It'd be nice to mention that sometimes package may not
be fetched and will give error during installation. Not
virtue of package problem but I/O problem. One common
problem faced is installation behind firewall.

CC @AbdealiJK 
