### PR TITLE
coala.less: Deprecated selectors updated

### DIFF
--- a/styles/coala.less
+++ b/styles/coala.less
@@ -1,6 +1,6 @@
 @import "ui-variables";
-atom-text-editor::shadow .linter-highlight, .linter-highlight {
-  &.info {
+atom-text-editor.editor .linter-highlight, .linter-highlight {
+  &.syntax--info {
     /* Style for Message Badges */
     &:not(.line-number) {
       background-color: @background-color-info;


### PR DESCRIPTION
The automatic translation of selectors
will be removed in a few release cycles of atom.
Hence they needed to be upgraded.

Fixes https://github.com/coala/coala-atom/issues/35