### PR TITLE
coala.less: selectors updated

### DIFF
--- a/styles/coala.less
+++ b/styles/coala.less
@@ -1,5 +1,5 @@
 @import "ui-variables";
-atom-text-editor::shadow .linter-highlight, .linter-highlight {
+atom-text-editor.editor .linter-highlight.syntax--info, .linter-highlight {
   &.info {
     /* Style for Message Badges */
     &:not(.line-number) {


### PR DESCRIPTION
The automatic translation of selectors
will be removed in a few release cycles of atom.
Hence, they needed to be upgraded.

Fixes https://github.com/coala/coala-atom/issues/35