### PR TITLE
README.md: Add alternative method for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ editor.
 
 # INSTALLATION
 
-1.  Install [coala](https://github.com/coala/coala)
-2.  `apm install coala` or use the atom GUI
+1. Install [coala](https://github.com/coala/coala)
+2. `apm install coala` or use the atom GUI
 
-    Note:
-     * If the [linter](https://github.com/steelbrain/linter) atom package is not currently installed, it will be installed for you.
-     * If you are behind a firewall and seeing SSL errors when installing packages, you may find the fix at [atom manual](http://flight-manual.atom.io/getting-started/sections/installing-atom/#setting-up-a-proxy)
+   Note:
+
+   - If the [linter](https://github.com/steelbrain/linter) atom package is not currently installed, it will be installed for you.
+   - If you are behind a firewall and seeing SSL errors when installing packages, you may find the fix at [atom manual](http://flight-manual.atom.io/getting-started/sections/installing-atom/#setting-up-a-proxy)
+   - If the above methods do not work, you can install the package manually as described in this [answer in atom discussion forum ](https://discuss.atom.io/t/manually-install-package/9251/14).
 
 # AUTHORS
 


### PR DESCRIPTION
README.md: Add alternative method for installation

Alternative method involves manual `git clone`, and `npm install`
