### PR TITLE
circle.yml: Specify nodejs version in circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+machine:
+  node:
+    version: 6.11.5
+
 dependencies:
   cache_directories:
     - ~/.pyenv/versions/3.4.3


### PR DESCRIPTION
`remark` which is used by MarkdownBear won't run under default nodejs
version in circleci.

Fixes https://github.com/coala/coala-atom/issues/81